### PR TITLE
bugfix critical error while one-to-many invalid data occurred

### DIFF
--- a/RelationBehavior.php
+++ b/RelationBehavior.php
@@ -158,7 +158,8 @@ class RelationBehavior extends Behavior
 
                     if (!empty($data['data'])) {
                         foreach ($data['data'] as $attributes) {
-                            $data['newModels'][] = new $class(array_merge($params, $attributes));
+                            $data['newModels'][] = new $class(array_merge($params,
+                                ArrayHelper::isAssociative($attributes) ? $attributes : []));
                         }
                     }
                 } else {


### PR DESCRIPTION
фикс бага с критической ошибкой при некорректных данных для множественных полей в yii2-relation
